### PR TITLE
main.go: log errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,10 +81,12 @@ func run(addr, bucketName string) error {
 			// Write the object to GCS
 			wc := object.NewWriter(ctx)
 			if _, err := io.Copy(wc, req.Body); err != nil {
+				log.Println(err)
 				http.Error(w, err.Error(), 500)
 				return
 			}
 			if err := wc.Close(); err != nil {
+				log.Println(err)
 				http.Error(w, err.Error(), 500)
 				return
 			}
@@ -92,6 +94,7 @@ func run(addr, bucketName string) error {
 			// Apply the headers
 			_, err := object.Update(ctx, objectAttrs)
 			if err != nil {
+				log.Println(err)
 				http.Error(w, err.Error(), 500)
 			}
 


### PR DESCRIPTION
The logs currently only show a

```
[negroni] 2019-08-30T06:45:28Z | 500 | 	 110.032028ms | localhost:3000 | PUT /my-path
```

And don't provide any detailed error information on why the request
failed, and we probably shouldn't propagate detailed error information
to clients.

However, sometimes more detailed error information is useful.

So add a log.Println(err) call, so we log the detailed error in syslog.